### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: required
 cache: packages
 
 warnings_are_errors: true
-r_build_args: '--no-build-vignettes --no-manual'
+r_build_args: '--no-manual'
 r_check_args: '--no-build-vignettes --no-manual'
 
 r:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ bioc_packages:
 
 after_success:
   ## coverage
-  - travis_wait 60 Rscript -e "covr::codecov(line_exclusions = list('R/plots.R', 'R/utils.R'))"
+  - travis_wait 80 Rscript -e "covr::codecov(line_exclusions = list('R/plots.R', 'R/utils.R'))"
   - R CMD BiocCheck .
 
 on_failure:

--- a/R/methyvim.R
+++ b/R/methyvim.R
@@ -232,10 +232,10 @@ methyvim <- function(data_grs,
       methyvim_est <- methyvim_tmle
     } else if (tmle_backend == "drtmle") {
       methyvim_est <- methyvim_tmle
-      #methyvim_est <- methyvim_drtmle
+      # methyvim_est <- methyvim_drtmle
     } else if (tmle_backend == "tmle.npvi") {
       methyvim_est <- methyvim_tmle
-      #methyvim_est <- methyvim_npvi
+      # methyvim_est <- methyvim_npvi
     }
 
     # avoid some try-errors by wrapping estimation function in try statement

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ JSTOR, 289–300.
 Chambaz, Antoine, Pierre Neuvial, and Mark J van der Laan. 2012.
 “Estimation of a Non-Parametric Variable Importance Measure of a
 Continuous Exposure.” *Electronic Journal of Statistics* 6. NIH Public
-Access:1059.
+Access: 1059.
 
 </div>
 
@@ -261,7 +261,7 @@ Cambridge University Press.
 Tuglus, Catherine, and Mark J van der Laan. 2009. “Modified FDR
 Controlling Procedure for Multi-Stage Analyses.” *Statistical
 Applications in Genetics and Molecular Biology* 8 (1). Walter de
-Gruyter:1–15. <https://doi.org/10.2202/1544-6115.1397>.
+Gruyter: 1–15. <https://doi.org/10.2202/1544-6115.1397>.
 
 </div>
 

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>/Users/nimahejazi/git/methyvim/CONTRIBUTING.md • methyvim</title>
+<title>Contributing to methyvim development • methyvim</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -25,9 +25,12 @@
 <link href="pkgdown.css" rel="stylesheet">
 <script src="jquery.sticky-kit.min.js"></script>
 <script src="pkgdown.js"></script>
-  
-  
-<meta property="og:title" content="/Users/nimahejazi/git/methyvim/CONTRIBUTING.md" />
+
+
+
+<meta property="og:title" content="Contributing to methyvim development" />
+
+
 <!-- mathjax -->
 <script src='https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
@@ -50,8 +53,12 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="index.html">methyvim</a>
+      <span class="navbar-brand">
+        <a class="navbar-link" href="index.html">methyvim</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released package">1.3.0</span>
+      </span>
     </div>
+
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
@@ -85,6 +92,7 @@
   </a>
 </li>
       </ul>
+      
     </div><!--/.nav-collapse -->
   </div><!--/.container -->
 </div><!--/.navbar -->
@@ -92,22 +100,23 @@
       
       </header>
 
-      <div class="row">
-  <div class="contents col-md-12">
+<div class="row">
+  <div class="contents col-md-9">
     <div class="page-header">
-      <h1>/Users/nimahejazi/git/methyvim/CONTRIBUTING.md</h1>
+      <h1>Contributing to methyvim development</h1>
     </div>
 
-<div class="section level1">
-<h1>Contributing to <code>methyvim</code> development</h1>
+<div id="contributing-to-methyvim-development" class="section level1">
+
 <p>We, the authors of the <code>methyvim</code> R package, use the same guide as is used for contributing to the development of the popular <code>tidyverse</code> ecosystem of R packages. This document is simply a formal re-statement of that fact.</p>
 <p>The goal of this guide is to help you get up and contributing to <code>methyvim</code> as quickly as possible. The guide is divided into two main pieces:</p>
 <ul>
 <li>Filing a bug report or feature request in an issue.</li>
 <li>Suggesting a change via a pull request.</li>
 </ul>
-<div class="section level2">
-<h2>Issues</h2>
+<div id="issues" class="section level2">
+<h2 class="hasAnchor">
+<a href="#issues" class="anchor"></a>Issues</h2>
 <p>When filing an issue, the most important thing is to include a minimal reproducible example so that we can quickly verify the problem, and then figure out how to fix it. There are three things you need to include to make your example reproducible: required packages, data, code.</p>
 <ol>
 <li><p><strong>Packages</strong> should be loaded at the top of the script, so it’s easy to see which ones the example needs.</p></li>
@@ -124,8 +133,9 @@
 <p>You can check you have actually made a reproducible example by starting up a fresh R session and pasting your script in.</p>
 <p>(Unless you’ve been specifically asked for it, please don’t include the output of <code>sessionInfo()</code>.)</p>
 </div>
-<div class="section level2">
-<h2>Pull requests</h2>
+<div id="pull-requests" class="section level2">
+<h2 class="hasAnchor">
+<a href="#pull-requests" class="anchor"></a>Pull requests</h2>
 <p>To contribute a change to <code>methyvim</code>, you follow these steps:</p>
 <ol>
 <li>Create a branch in git and make your changes.</li>
@@ -169,6 +179,8 @@
 
       </footer>
    </div>
+
+  
 
   </body>
 </html>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Citation and Authors • methyvim</title>
+<title>License • methyvim</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -28,7 +28,7 @@
 
 
 
-<meta property="og:title" content="Citation and Authors" />
+<meta property="og:title" content="License" />
 
 
 <!-- mathjax -->
@@ -43,7 +43,7 @@
   </head>
 
   <body>
-    <div class="container template-citation-authors">
+    <div class="container template-title-body">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
@@ -103,42 +103,31 @@
 <div class="row">
   <div class="contents col-md-9">
     <div class="page-header">
-      <h1>Citation</h1>
+      <h1>License</h1>
     </div>
 
-    <p>Hejazi NS, Phillips RV, Hubbard AE, van der Laan MJ (2018).
-&ldquo;methyvim: Targeted and model-free analysis of differential
-methylation in R.&rdquo; 
-</p>
-    <pre>@Misc{,
-  year = {2018},
-  publisher = {forthcoming},
-  author = {Nima S. Hejazi and Rachael V. Phillips and Alan E. Hubbard and Mark J. {van der Laan}},
-  title = {methyvim: Targeted and model-free analysis of differential
-                    methylation in R},
-}</pre>
-    <div class="page-header">
-      <h1>Authors</h1>
-    </div>
+<pre>MIT License
 
-    <ul class="list-unstyled">
-      <li>
-        <p><strong>Nima Hejazi</strong>. Author, maintainer, copyright holder. <a href='https://orcid.org/0000-0002-7127-2789' target='orcid.widget'><img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' height='16'></a>
-        </p>
-      </li>
-      <li>
-        <p><strong>Rachael Phillips</strong>. Contributor. <a href='https://orcid.org/0000-0002-8474-591X' target='orcid.widget'><img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' height='16'></a>
-        </p>
-      </li>
-      <li>
-        <p><strong>Mark van der Laan</strong>. Author, thesis advisor. 
-        </p>
-      </li>
-      <li>
-        <p><strong>Alan Hubbard</strong>. Contributor, thesis advisor. <a href='https://orcid.org/0000-0002-3769-0127' target='orcid.widget'><img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' height='16'></a>
-        </p>
-      </li>
-    </ul>
+Copyright (c) 2017 Nima S. Hejazi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
 
   </div>
 

--- a/docs/docsearch.css
+++ b/docs/docsearch.css
@@ -1,0 +1,145 @@
+/* Docsearch -------------------------------------------------------------- */
+/*
+  Source: https://github.com/algolia/docsearch/
+  License: MIT
+*/
+
+.algolia-autocomplete {
+  display: block;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.algolia-autocomplete .ds-dropdown-menu {
+  width: 100%;
+  min-width: none;
+  max-width: none;
+  padding: .75rem 0;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, .1);
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .175);
+}
+
+@media (min-width:768px) {
+  .algolia-autocomplete .ds-dropdown-menu {
+      width: 175%
+  }
+}
+
+.algolia-autocomplete .ds-dropdown-menu::before {
+  display: none
+}
+
+.algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
+  padding: 0;
+  background-color: rgb(255,255,255);
+  border: 0;
+  max-height: 80vh;
+}
+
+.algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
+  margin-top: 0
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion {
+  padding: 0;
+  overflow: visible
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
+  padding: .125rem 1rem;
+  margin-top: 0;
+  font-size: 1.3em;
+  font-weight: 500;
+  color: #00008B;
+  border-bottom: 0
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
+    float: none;
+    padding-top: 0
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+  float: none;
+  width: auto;
+  padding: 0;
+  text-align: left
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content {
+  float: none;
+  width: auto;
+  padding: 0
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content::before {
+  display: none
+}
+
+.algolia-autocomplete .ds-suggestion:not(:first-child) .algolia-docsearch-suggestion--category-header {
+  padding-top: .75rem;
+  margin-top: .75rem;
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .ds-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  display: block;
+  padding: .1rem 1rem;
+  margin-bottom: 0.1;
+  font-size: 1.0em;
+  font-weight: 400
+  /* display: none */
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--title {
+  display: block;
+  padding: .25rem 1rem;
+  margin-bottom: 0;
+  font-size: 0.9em;
+  font-weight: 400
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text {
+  padding: 0 1rem .5rem;
+  margin-top: -.25rem;
+  font-size: 0.8em;
+  font-weight: 400;
+  line-height: 1.25
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+  float: none;
+  width: auto;
+  height: auto;
+  padding: .75rem 1rem 0;
+  font-size: .95rem;
+  line-height: 1;
+  color: #767676;
+  background-color: rgb(255, 255, 255);
+  border-top: 1px solid rgba(0, 0, 0, .1)
+}
+
+.algolia-autocomplete .algolia-docsearch-footer--logo {
+  display: inline;
+  overflow: visible;
+  color: inherit;
+  text-indent: 0;
+  background: 0 0
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #FF8C00;
+  background: rgba(232, 189, 54, 0.1)
+}
+
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0 rgba(105, 105, 105, .5)
+}
+
+.algolia-autocomplete .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
+  background-color: rgba(192, 192, 192, .15)
+}

--- a/docs/jquery.sticky-kit.min.js
+++ b/docs/jquery.sticky-kit.min.js
@@ -1,5 +1,7 @@
+/* Sticky-kit v1.1.2 | WTFPL | Leaf Corcoran 2015 |  */
 /*
- Sticky-kit v1.1.2 | WTFPL | Leaf Corcoran 2015 | http://leafo.net
+  Source: https://github.com/leafo/sticky-kit
+  License: MIT
 */
 (function(){var b,f;b=this.jQuery||window.jQuery;f=b(window);b.fn.stick_in_parent=function(d){var A,w,J,n,B,K,p,q,k,E,t;null==d&&(d={});t=d.sticky_class;B=d.inner_scrolling;E=d.recalc_every;k=d.parent;q=d.offset_top;p=d.spacer;w=d.bottoming;null==q&&(q=0);null==k&&(k=void 0);null==B&&(B=!0);null==t&&(t="is_stuck");A=b(document);null==w&&(w=!0);J=function(a,d,n,C,F,u,r,G){var v,H,m,D,I,c,g,x,y,z,h,l;if(!a.data("sticky_kit")){a.data("sticky_kit",!0);I=A.height();g=a.parent();null!=k&&(g=g.closest(k));
 if(!g.length)throw"failed to find stick parent";v=m=!1;(h=null!=p?p&&a.closest(p):b("<div />"))&&h.css("position",a.css("position"));x=function(){var c,f,e;if(!G&&(I=A.height(),c=parseInt(g.css("border-top-width"),10),f=parseInt(g.css("padding-top"),10),d=parseInt(g.css("padding-bottom"),10),n=g.offset().top+c+f,C=g.height(),m&&(v=m=!1,null==p&&(a.insertAfter(h),h.detach()),a.css({position:"",top:"",width:"",bottom:""}).removeClass(t),e=!0),F=a.offset().top-(parseInt(a.css("margin-top"),10)||0)-q,

--- a/docs/pkgdown.css
+++ b/docs/pkgdown.css
@@ -1,13 +1,32 @@
-/* Sticker footer */
+/* Sticky footer */
+
+/**
+ * Basic idea: https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+ * Details: https://github.com/philipwalton/solved-by-flexbox/blob/master/assets/css/components/site.css
+ *
+ * .Site -> body > .container
+ * .Site-content -> body > .container .row
+ * .footer -> footer
+ *
+ * Key idea seems to be to ensure that .container and __all its parents__
+ * have height set to 100%
+ *
+ */
+
+html, body {
+  height: 100%;
+}
+
 body > .container {
   display: flex;
-  padding-top: 60px;
-  min-height: calc(100vh);
+  height: 100%;
   flex-direction: column;
+
+  padding-top: 60px;
 }
 
 body > .container .row {
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 footer {
@@ -16,6 +35,7 @@ footer {
   border-top: 1px solid #e5e5e5;
   color: #666;
   display: flex;
+  flex-shrink: 0;
 }
 footer p {
   margin-bottom: 0;
@@ -36,6 +56,12 @@ img.icon {
 
 img {
   max-width: 100%;
+}
+
+/* Typographic tweaking ---------------------------------*/
+
+.contents h1.page-header {
+  margin-top: calc(-60px + 1em);
 }
 
 /* Section anchors ---------------------------------*/
@@ -68,7 +94,7 @@ a.anchor {
 
 .contents h1, .contents h2, .contents h3, .contents h4 {
   padding-top: 60px;
-  margin-top: -60px;
+  margin-top: -40px;
 }
 
 /* Static header placement on mobile devices */
@@ -108,7 +134,6 @@ a.anchor {
 /* Reference index & topics ----------------------------------------------- */
 
 .ref-index th {font-weight: normal;}
-.ref-index h2 {font-size: 20px;}
 
 .ref-index td {vertical-align: top;}
 .ref-index .alias {width: 40%;}
@@ -191,4 +216,12 @@ a.sourceLine:hover {
 
 .hasCopyButton:hover button.btn-copy-ex {
   visibility: visible;
+}
+
+/* mark.js ----------------------------*/
+
+mark {
+  background-color: rgba(255, 255, 51, 0.5);
+  border-bottom: 2px solid rgba(255, 153, 51, 0.3);
+  padding: 1px;
 }

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -14,6 +14,8 @@ $(function() {
     offset: 60
   });
 
+  $('[data-toggle="tooltip"]').tooltip();
+
   var cur_path = paths(location.pathname);
   $("#navbar ul li a").each(function(index, value) {
     if (value.text == "Home")
@@ -31,6 +33,45 @@ $(function() {
   });
 });
 
+$(document).ready(function() {
+  // do keyword highlighting
+  /* modified from https://jsfiddle.net/julmot/bL6bb5oo/ */
+  var mark = function() {
+
+    var referrer = document.URL ;
+    var paramKey = "q" ;
+
+    if (referrer.indexOf("?") !== -1) {
+      var qs = referrer.substr(referrer.indexOf('?') + 1);
+      var qs_noanchor = qs.split('#')[0];
+      var qsa = qs_noanchor.split('&');
+      var keyword = "";
+
+      for (var i = 0; i < qsa.length; i++) {
+        var currentParam = qsa[i].split('=');
+
+        if (currentParam.length !== 2) {
+          continue;
+        }
+
+        if (currentParam[0] == paramKey) {
+          keyword = decodeURIComponent(currentParam[1].replace(/\+/g, "%20"));
+        }
+      }
+
+      if (keyword !== "") {
+        $(".contents").unmark({
+          done: function() {
+            $(".contents").mark(keyword);
+          }
+        });
+      }
+    }
+  };
+
+  mark();
+});
+
 function paths(pathname) {
   var pieces = pathname.split("/");
   pieces.shift(); // always starts with /
@@ -44,6 +85,11 @@ function paths(pathname) {
 function is_prefix(needle, haystack) {
   if (needle.length > haystack.lengh)
     return(false);
+
+  // Special case for length-0 haystack, since for loop won't run
+  if (haystack.length === 0) {
+    return(needle.length === 0);
+  }
 
   for (var i = 0; i < haystack.length; i++) {
     if (needle[i] != haystack[i])
@@ -92,3 +138,37 @@ if(Clipboard.isSupported()) {
   });
 }
 
+/* Search term highlighting ------------------------------*/
+
+function matchedWords(hit) {
+  var words = [];
+
+  var hierarchy = hit._highlightResult.hierarchy;
+  // loop to fetch from lvl0, lvl1, etc.
+  for (var idx in hierarchy) {
+    words = words.concat(hierarchy[idx].matchedWords);
+  }
+
+  var content = hit._highlightResult.content;
+  if (content) {
+    words = words.concat(content.matchedWords);
+  }
+
+  // return unique words
+  var words_uniq = [...new Set(words)];
+  return words_uniq;
+}
+
+function updateHitURL(hit) {
+
+  var words = matchedWords(hit);
+  var url = "";
+
+  if (hit.anchor) {
+    url = hit.url_without_anchor + '?q=' + escape(words.join(" ")) + '#' + hit.anchor;
+  } else {
+    url = hit.url + '?q=' + escape(words.join(" "));
+  }
+
+  return url;
+}

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,7 +1,6 @@
-pandoc: 2.1.3
-pkgdown: 0.1.0.9000
-pkgdown_sha: 17f683717d0a1547f13a08a259b34c58927452d6
+pandoc: '2.2'
+pkgdown: 1.0.0
+pkgdown_sha: ~
 articles:
   using_methyvim: using_methyvim.html
-  vignette-refs.bib: vignette-refs.bib
 


### PR DESCRIPTION
This PR fixes a warning issued by `R CMD check` (causing a failure on Travis builds) due to the presence of `Rmd` vignettes in a `vignettes` subdirectory, without compiled versions of these vignettes present in `inst/doc` in the built source package. This is due to a poor use of the flag `--no-build-vignettes` as input to `R CMD build` in the `.travis.yml` file. The opportunity is also taken to re-style the code and update the `pkgdown` site.