### PR TITLE
fix BiocManager; pin appveyor to r-devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,16 @@ r:
   - bioc-devel
 
 before_install:
-  - Rscript -e 'BiocManager::install(version = "devel", ask = FALSE)'
+  - Rscript -e 'BiocManager::install(ask = FALSE)'
 
 r_packages:
   - devtools
   - sessioninfo
   - covr
   - BiocManager
+  - cluster
+  - ggplot2
+  - ggsci
 
 r_github_packages:
   - r-lib/sessioninfo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: methyvim
 Title: Targeted, Robust, and Model-free Differential Methylation Analysis
-Version: 1.9.0
+Version: 1.9.1
 Authors@R: c(
   person("Nima", "Hejazi", email = "nh@nimahejazi.org",
          role = c("aut", "cre", "cph"),
@@ -67,7 +67,7 @@ Suggests:
   minfiData,
   methyvimData
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 biocViews:
   Clustering,
   DNAMethylation,

--- a/R/force_positivity.R
+++ b/R/force_positivity.R
@@ -26,7 +26,7 @@
 force_positivity <- function(A, W, pos_min = 0.1, q_init = 10) {
   stopifnot(length(A) == nrow(W))
 
-  if (class(W) != "data.frame") W <- as.data.frame(W) # cover use of "ncol"
+  if (!is.data.frame(W)) W <- as.data.frame(W) # cover use of "ncol"
   out_w <- NULL # concatenate W columnwise as we discretize each covar below
 
   for (obs_w in seq_len(ncol(W))) {

--- a/R/plots.R
+++ b/R/plots.R
@@ -104,8 +104,8 @@ plot.methytmle <- function(x, ..., type = "both") {
 #'  transformation into influence curve space (with respect to the target
 #'  parameter of interest). The latter uses the fact that the parameters have
 #'  asymptotically linear representations to obtain a rotation of the raw data
-#'  into an alternative space; moreover, in this setting, the heatmap reduces to
-#'  visualizing a supervised clustering procedure.
+#'  into an alternative space; moreover, in this setting, the heatmap reduces
+#'  to visualizing a supervised clustering procedure.
 #'
 #' @return Nothing. This function is called for its side-effect of outputting a
 #'  heatmap to the graphics device. The heatmap is constructed using the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,10 @@ build_script:
   - echo Current directory=%CD%
   - travis-tool.sh install_r base64 BiocManager testthat knitr
   - travis-tool.sh install_github r-lib/remotes r-lib/covr
-  - travis-tool.sh install_bioc BiocStyle BiocCheck BiocGenerics S4Vectors
-  - travis-tool.sh install_bioc SummarizedExperiment IRanges limma minfi
-  - travis-tool.sh install_bioc GenomeInfoDb bumphunter minfiData
+  - travis-tool.sh install_bioc BiocStyle BiocCheck BiocGenerics S4Vectors \
+    SummarizedExperiment IRanges limma minfi GenomeInfoDb bumphunter minfiData
+  - travis-tool.sh install_r ggplot2 ggsci gridExtra superheat gtools earth \
+    gam arm SuperLearner tmle BatchJobs future doFuture
   - travis-tool.sh install_github nhejazi/methyvimData
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,15 @@
+#----------------------------------------------------------------
+# AppVeyor configuration for R packages
+#
+# REFERENCES:
+# * AppVeyor CI: https://ci.appveyor.com/
+# * r-appveyor: https://github.com/krlmlr/r-appveyor
+#
+# Validate your .appveyor.yml file at
+# https://ci.appveyor.com/tools/validate-yaml
+
 # DO NOT CHANGE the "init" and "install" sections below
+#----------------------------------------------------------------
 
 # Download script file from GitHub
 init:
@@ -22,25 +33,22 @@ environment:
   global:
     WARNINGS_ARE_ERRORS: 0
     _R_CHECK_FORCE_SUGGESTS_: false
-    USE_RTOOLS: true
     R_REMOTES_STANDALONE: true
+    USE_RTOOLS: true
     PKGTYPE: both
 
   matrix:
-    - R_VERSION: release
+    - R_VERSION: devel
       R_ARCH: x64
 
 build_script:
   - echo Current directory=%CD%
-  - travis-tool.sh install_r base64
+  - travis-tool.sh install_r base64 BiocManager testthat knitr
   - travis-tool.sh install_github r-lib/remotes r-lib/covr
-  - travis-tool.sh install_r BiocManager testthat knitr
   - travis-tool.sh install_bioc BiocStyle BiocCheck BiocGenerics S4Vectors
   - travis-tool.sh install_bioc SummarizedExperiment IRanges limma minfi
   - travis-tool.sh install_bioc GenomeInfoDb bumphunter minfiData
   - travis-tool.sh install_github nhejazi/methyvimData
-  - travis-tool.sh install_bioc_deps
-  - travis-tool.sh install_deps
 
 test_script:
   - travis-tool.sh run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
   - travis-tool.sh install_bioc BiocStyle BiocCheck BiocGenerics S4Vectors \
     SummarizedExperiment IRanges limma minfi GenomeInfoDb bumphunter minfiData
   - travis-tool.sh install_r ggplot2 ggsci gridExtra superheat gtools earth \
-    gam arm SuperLearner tmle BatchJobs future doFuture
+    gam arm SuperLearner tmle BatchJobs future doFuture tmle.npvi
   - travis-tool.sh install_github nhejazi/methyvimData
 
 test_script:

--- a/man/methyheat.Rd
+++ b/man/methyheat.Rd
@@ -23,8 +23,8 @@ the set of top CpG sites or to plot the measurements after applying a
 transformation into influence curve space (with respect to the target
 parameter of interest). The latter uses the fact that the parameters have
 asymptotically linear representations to obtain a rotation of the raw data
-into an alternative space; moreover, in this setting, the heatmap reduces to
-visualizing a supervised clustering procedure.}
+into an alternative space; moreover, in this setting, the heatmap reduces
+to visualizing a supervised clustering procedure.}
 }
 \value{
 Nothing. This function is called for its side-effect of outputting a

--- a/man/methytmle-class.Rd
+++ b/man/methytmle-class.Rd
@@ -14,8 +14,6 @@ vim(object)
 }
 \arguments{
 \item{object}{S4 object of class \code{methytmle}.}
-
-\item{object}{S4 object of class \code{methytmle}.}
 }
 \value{
 \code{methytmle} object, subclassed from \code{GenomicRatioSet}.

--- a/man/methyvim.Rd
+++ b/man/methyvim.Rd
@@ -4,16 +4,28 @@
 \alias{methyvim}
 \title{Differential Methylation Statistics with Variable Importance Measures}
 \usage{
-methyvim(data_grs, var_int, vim = c("ate", "rr", "npvi"),
-  type = c("Beta", "Mval"), filter = c("limma"),
-  filter_cutoff = 0.05, window_bp = 1000, corr_max = 0.75,
-  obs_per_covar = 20, sites_comp = NULL, parallel = TRUE,
-  future_param = NULL, bppar_type = NULL, return_ic = FALSE,
-  shrink_ic = FALSE, tmle_type = c("glm", "sl"),
-  tmle_args = list(g_lib = c("SL.mean", "SL.glm", "SL.bayesglm",
-  "SL.gam"), Q_lib = c("SL.mean", "SL.glm", "SL.gam", "SL.earth"), cv_folds
-  = 5, npvi_cutoff = 0.25, npvi_descr = NULL), tmle_backend = c("tmle",
-  "drtmle", "tmle.npvi"))
+methyvim(
+  data_grs,
+  var_int,
+  vim = c("ate", "rr", "npvi"),
+  type = c("Beta", "Mval"),
+  filter = c("limma"),
+  filter_cutoff = 0.05,
+  window_bp = 1000,
+  corr_max = 0.75,
+  obs_per_covar = 20,
+  sites_comp = NULL,
+  parallel = TRUE,
+  future_param = NULL,
+  bppar_type = NULL,
+  return_ic = FALSE,
+  shrink_ic = FALSE,
+  tmle_type = c("glm", "sl"),
+  tmle_args = list(g_lib = c("SL.mean", "SL.glm", "SL.bayesglm", "SL.gam"), Q_lib =
+    c("SL.mean", "SL.glm", "SL.gam", "SL.earth"), cv_folds = 5, npvi_cutoff = 0.25,
+    npvi_descr = NULL),
+  tmle_backend = c("tmle", "drtmle", "tmle.npvi")
+)
 }
 \arguments{
 \item{data_grs}{An object of class \code{\link[minfi]{GenomicRatioSet}},

--- a/man/methyvim_tmle.Rd
+++ b/man/methyvim_tmle.Rd
@@ -4,11 +4,20 @@
 \alias{methyvim_tmle}
 \title{Differential Methylation with Classical Target Parameters}
 \usage{
-methyvim_tmle(target_site, methytmle_screened, var_of_interest,
-  type = c("Beta", "Mval"), corr, obs_per_covar,
-  target_param = c("ate", "rr"), g_lib = c("SL.mean", "SL.glm",
-  "SL.glm.interaction"), Q_lib = c("SL.mean", "SL.glm", "SL.gam",
-  "SL.earth"), cv_folds = 5, ..., return_ic = FALSE)
+methyvim_tmle(
+  target_site,
+  methytmle_screened,
+  var_of_interest,
+  type = c("Beta", "Mval"),
+  corr,
+  obs_per_covar,
+  target_param = c("ate", "rr"),
+  g_lib = c("SL.mean", "SL.glm", "SL.glm.interaction"),
+  Q_lib = c("SL.mean", "SL.glm", "SL.gam", "SL.earth"),
+  cv_folds = 5,
+  ...,
+  return_ic = FALSE
+)
 }
 \arguments{
 \item{target_site}{Numeric indicating the column containing the screened

--- a/man/set_parallel.Rd
+++ b/man/set_parallel.Rd
@@ -4,8 +4,7 @@
 \alias{set_parallel}
 \title{Parallelization with Futures and BiocParallel}
 \usage{
-set_parallel(parallel = c(TRUE, FALSE), future_param = NULL,
-  bppar_type = NULL)
+set_parallel(parallel = c(TRUE, FALSE), future_param = NULL, bppar_type = NULL)
 }
 \arguments{
 \item{parallel}{Logical indicating whether parallelization ought to be used.


### PR DESCRIPTION
The purpose of this PR is to resolve issues with unit tests across platforms and build problems on continuous integration services. CI build problems arose from the use of `BiocManager::install(version = "devel", ask = FALSE)` on Travis and (implicitly, through `install_bioc`) on Appveyor. By removing the specification of `"devel"` in that function call, `BiocManager::install` then defaults to setting the version based on a call to `BiocManager::version()`, which returns the correct version of Bioconductor for the version of R being used. In prior attempts, this use of `"devel"` caused build issues due to an incompatibility between the release version of R and the development version of Bioconductor. This is now fixed.